### PR TITLE
Search at depth 2 for the packagen when generating prs/mrs.

### DIFF
--- a/bin/generate-submission-mrs.sh
+++ b/bin/generate-submission-mrs.sh
@@ -55,7 +55,7 @@ printf 'Syncing data...\n'
       git checkout -b "$package-$checksum"
     )
 
-    found="$(find "$TMP_FOLDER/slackbuilds" -type d -name "$package" \! -path '*/.git/*')"
+    found="$(find "$TMP_FOLDER/slackbuilds" -type d -name "$package" -maxdepth 2 -mindepth 2 \! -path '*/.git/*')"
 
     if [ "" = "$found" ] ; then
       printf 'New submission found %s\n' "$package"

--- a/bin/generate-submission-prs.sh
+++ b/bin/generate-submission-prs.sh
@@ -59,7 +59,7 @@ printf 'Syncing data...\n'
       git checkout -b "$package-$checksum"
     )
 
-    found="$(find "$TMP_FOLDER/slackbuilds" -type d -name "$package" \! -path '*/.git/*')"
+    found="$(find "$TMP_FOLDER/slackbuilds" -type d -name "$package" -maxdepth 2 -mindepth 2 \! -path '*/.git/*')"
 
     if [ "" = "$found" ] ; then
       printf 'New submission found %s\n' "$package"


### PR DESCRIPTION
Builds will also be inside a category directly and no further down.

This avoids finding directories belonging to a slackbuild with the same
name as another build.

Closes #743